### PR TITLE
Convert Configuration to an actual BaseModel type

### DIFF
--- a/example/config.py
+++ b/example/config.py
@@ -14,7 +14,6 @@ from configaroo import Configuration
 
 class PlayerConfig(BaseModel):
     color: str
-    name: str
 
 
 class UserConfig(BaseModel):
@@ -42,8 +41,8 @@ class ConfigModel(BaseModel):
 config = Configuration.from_file(
     Path(__file__).parent / "settings.toml",
     envs={"EXAMPLE_SECRET": "server.secret", "BOARD_SIZE": "constant.board_size"},
-    model=ConfigModel,
-)
+).with_model(model=ConfigModel)
+
 
 if __name__ == "__main__":
     print(config)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,7 +10,7 @@ from configaroo import Configuration
 
 def test_can_validate(config, model):
     """Test that a configuration can be validated"""
-    assert config.validate(model)
+    assert config.validate_model(model)
 
 
 def test_wrong_key_raises(model):
@@ -19,24 +19,37 @@ def test_wrong_key_raises(model):
         digit=4, nested={"pie": 3.14, "seven": 7}, path="files/config.toml"
     )
     with pytest.raises(pydantic.ValidationError):
-        config.validate(model)
+        config.validate_model(model)
 
 
 def test_missing_key_raises(model):
     """Test that a missing key raises an error"""
     config = Configuration(nested={"pie": 3.14, "seven": 7}, path="files/config.toml")
     with pytest.raises(pydantic.ValidationError):
-        config.validate(model)
+        config.validate_model(model)
 
 
 def test_extra_key_ok(config, model):
     """Test that an extra key raises when the model is strict"""
     updated_config = config | {"new_word": "cuckoo-bird"}
     with pytest.raises(pydantic.ValidationError):
-        updated_config.validate(model)
+        updated_config.validate_model(model)
 
 
 def test_type_conversion(config, model):
-    config_w_types = config.convert(model)
+    """Test that types can be converted based on the model"""
+    config_w_types = config.convert_model(model)
     assert isinstance(config.paths.relative, str)
     assert isinstance(config_w_types.paths.relative, Path)
+
+
+def test_converted_model_is_pydantic(config, model):
+    """Test that the converted model is a BaseModel which helps with auto-complete"""
+    config_w_types = config.convert_model(model=model)
+    assert isinstance(config_w_types, pydantic.BaseModel)
+
+
+def test_validate_and_convert(config, model):
+    config_w_model = config.with_model(model)
+    assert isinstance(config_w_model, pydantic.BaseModel)
+    assert isinstance(config_w_model.paths.relative, Path)


### PR DESCRIPTION
After the configuration has been set up (environment variables added, dynamic variables parsed, and model validated) we can convert it to a Pydantic model. This gives extra conveniences like tab-completion and discoverability in the IDEs