### PR TITLE
Allow nonexisting files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: mypy
-        additional_dependencies: [pydantic>=2.0, pyplugs>=0.5.4 , pytest>=8.4.1, rich>=14.1.0]
+        additional_dependencies: [pydantic>=2.0, pyplugs>=0.5.4 , pytest>=8.4.1, rich>=14.1.0, tomli-w>=1.2.0]
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7

--- a/examples/validate/config.py
+++ b/examples/validate/config.py
@@ -44,10 +44,13 @@ class ConfigModel(ExactBaseModel):
 
 def get_configuration() -> ConfigModel:
     """Read and validate the configuration."""
-    return Configuration.from_file(
-        Path(__file__).parent / "settings.toml",
-        envs={"EXAMPLE_SECRET": "server.secret", "BOARD_SIZE": "constant.board_size"},
-    ).with_model(model=ConfigModel)
+    return (
+        Configuration.from_file(Path(__file__).parent / "settings.toml")
+        .add_envs(
+            {"EXAMPLE_SECRET": "server.secret", "BOARD_SIZE": "constant.board_size"}
+        )
+        .with_model(model=ConfigModel)
+    )
 
 
 if __name__ == "__main__":

--- a/src/configaroo/configuration.py
+++ b/src/configaroo/configuration.py
@@ -51,23 +51,6 @@ class Configuration(UserDict[str, Any]):
         )
         return cls(config_dict)
 
-    def initialize(
-        self,
-        envs: dict[str, str] | None = None,
-        env_prefix: str = "",
-        extra_dynamic: dict[str, Any] | None = None,
-    ) -> Self:
-        """Initialize a configuration.
-
-        The initialization adds environment variables and parses dynamic values.
-        """
-        self = self if envs is None else self.add_envs(envs, prefix=env_prefix)  # noqa: PLW0642
-        return self.parse_dynamic(extra_dynamic)
-
-    def with_model(self, model: type[ModelT]) -> ModelT:
-        """Apply a pydantic model to a configuration."""
-        return self.validate_model(model).convert_model(model)
-
     def __getitem__(self, key: str) -> Any:  # noqa: ANN401
         """Make sure nested sections have type Configuration."""
         value = self.data[key]
@@ -175,6 +158,10 @@ class Configuration(UserDict[str, Any]):
     def convert_model(self, model: type[ModelT]) -> ModelT:
         """Convert data types to match the given model."""
         return model(**self.data)
+
+    def with_model(self, model: type[ModelT]) -> ModelT:
+        """Apply a pydantic model to a configuration."""
+        return self.validate_model(model).convert_model(model)
 
     def to_dict(self) -> dict[str, Any]:
         """Dump the configuration into a Python dictionary."""

--- a/src/configaroo/configuration.py
+++ b/src/configaroo/configuration.py
@@ -208,9 +208,7 @@ def _get_rich_print() -> Callable[[str], None]:  # pragma: no cover
 
         return Console().print
     except ImportError:
-        import builtins  # noqa: PLC0415
-
-        return builtins.print
+        return print
 
 
 def _print_dict_as_tree(

--- a/src/configaroo/configuration.py
+++ b/src/configaroo/configuration.py
@@ -33,16 +33,25 @@ class Configuration(UserDict[str, Any]):
         return configuration
 
     @classmethod
-    def from_file(
+    def from_file(  # noqa: PLR0913
         cls,
         file_path: str | Path,
+        *,
         loader: str | None = None,
+        not_exist_ok: bool = False,
         envs: dict[str, str] | None = None,
         env_prefix: str = "",
         extra_dynamic: dict[str, Any] | None = None,
     ) -> Self:
-        """Read a Configuration from a file."""
-        config_dict = loaders.from_file(file_path, loader=loader)
+        """Read a Configuration from a file.
+
+        If not_exist_ok is True, then a missing file returns an empty
+        configuration. This may be useful if the configuration is potentially
+        populated by environment variables.
+        """
+        config_dict = loaders.from_file(
+            file_path, loader=loader, not_exist_ok=not_exist_ok
+        )
         return cls(config_dict).initialize(
             envs=envs, env_prefix=env_prefix, extra_dynamic=extra_dynamic
         )

--- a/src/configaroo/configuration.py
+++ b/src/configaroo/configuration.py
@@ -33,15 +33,12 @@ class Configuration(UserDict[str, Any]):
         return configuration
 
     @classmethod
-    def from_file(  # noqa: PLR0913
+    def from_file(
         cls,
         file_path: str | Path,
         *,
         loader: str | None = None,
         not_exist_ok: bool = False,
-        envs: dict[str, str] | None = None,
-        env_prefix: str = "",
-        extra_dynamic: dict[str, Any] | None = None,
     ) -> Self:
         """Read a Configuration from a file.
 
@@ -52,9 +49,7 @@ class Configuration(UserDict[str, Any]):
         config_dict = loaders.from_file(
             file_path, loader=loader, not_exist_ok=not_exist_ok
         )
-        return cls(config_dict).initialize(
-            envs=envs, env_prefix=env_prefix, extra_dynamic=extra_dynamic
-        )
+        return cls(config_dict)
 
     def initialize(
         self,

--- a/src/configaroo/loaders/__init__.py
+++ b/src/configaroo/loaders/__init__.py
@@ -26,9 +26,14 @@ def loader_names() -> list[str]:
     return sorted(pyplugs.names(PACKAGE))
 
 
-def from_file(path: str | Path, loader: str | None = None) -> dict[str, Any]:
+def from_file(
+    path: str | Path, *, loader: str | None = None, not_exist_ok: bool = False
+) -> dict[str, Any]:
     """Load a file using a loader defined by the suffix if necessary."""
     path = Path(path)
+    if not path.exists() and not_exist_ok:
+        return {}
+
     loader = path.suffix.lstrip(".") if loader is None else loader
     try:
         return load(loader, path=path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,22 @@
 
 import json
 from pathlib import Path
-from types import ModuleType
 
 import pytest
 import tomli_w
 
 from configaroo import Configuration
 from tests.schema import ConfigSchema
+
+
+def toml_dumps(config: Configuration) -> str:
+    """Dump a configuration to a TOML string."""
+    return tomli_w.dumps(config.to_dict())
+
+
+def json_dumps(config: Configuration) -> str:
+    """Dump a configuration to a JSON string. Include a final newline."""
+    return json.dumps(config.to_dict(), indent=4) + "\n"
 
 
 @pytest.fixture
@@ -47,30 +56,28 @@ def base_path() -> Path:
 @pytest.fixture
 def toml_path(base_path: Path, config: Configuration) -> Path:
     """Return a path to a TOML file representing the configuration."""
-    return write_file(base_path / "files" / "config.toml", tomli_w, config)
+    return write_file(base_path / "files" / "config.toml", toml_dumps(config))
 
 
 @pytest.fixture
 def other_toml_path(base_path: Path, config: Configuration) -> Path:
     """Return an alternative path to a TOML file representing the configuration."""
-    return write_file(base_path / "files" / "tomlfile", tomli_w, config)
+    return write_file(base_path / "files" / "tomlfile", toml_dumps(config))
 
 
 @pytest.fixture
 def json_path(base_path: Path, config: Configuration) -> Path:
     """Return a path to a JSON file representing the configuration."""
-    return write_file(base_path / "files" / "config.json", json, config, indent=4)
+    return write_file(base_path / "files" / "config.json", json_dumps(config))
 
 
 @pytest.fixture
 def other_json_path(base_path: Path, config: Configuration) -> Path:
     """Return a path to a JSON file representing the configuration."""
-    return write_file(base_path / "files" / "jsonfile", json, config, indent=4)
+    return write_file(base_path / "files" / "jsonfile", json_dumps(config))
 
 
-def write_file(
-    path: Path, lib: ModuleType, config: Configuration, **kwargs: str | int
-) -> Path:
+def write_file(path: Path, text: str) -> Path:
     """Write a configuration to file. Return path for convenience."""
-    path.write_text(lib.dumps(config.to_dict(), **kwargs), encoding="utf-8")
+    path.write_text(text, encoding="utf-8")
     return path

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -8,12 +8,6 @@ import configaroo
 from configaroo import Configuration, configuration
 
 
-@pytest.fixture
-def file_path() -> Path:
-    """Return the path to the current file."""
-    return Path(__file__).resolve()
-
-
 def test_read_simple_values_as_attributes(config: Configuration) -> None:
     """Test attribute access for simple values."""
     assert config.number == 42

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -38,6 +38,12 @@ def test_error_on_wrong_format(toml_path: Path) -> None:
         Configuration.from_file(toml_path, loader="json")
 
 
+def test_file_may_be_allowed_to_not_exist() -> None:
+    """Test that not_exist_ok can suppress error when file doesn't exist."""
+    config = Configuration.from_file("non-existent.json", not_exist_ok=True)
+    assert config.data == {}
+
+
 def test_can_read_json_values(json_path: Path) -> None:
     """Test that values can be accessed."""
     config = Configuration.from_file(json_path)

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -38,6 +38,12 @@ def test_error_on_wrong_format(json_path: Path) -> None:
         Configuration.from_file(json_path, loader="toml")
 
 
+def test_file_may_be_allowed_to_not_exist() -> None:
+    """Test that not_exist_ok can suppress error when file doesn't exist."""
+    config = Configuration.from_file("non-existent.toml", not_exist_ok=True)
+    assert config.data == {}
+
+
 def test_can_read_toml_values(toml_path: Path) -> None:
     """Test that values can be accessed."""
     config = Configuration.from_file(toml_path)


### PR DESCRIPTION
Adds a `not_exist_ok` parameter to `Configuration.from_file()` which allows configuration files to not exist. This may be useful for configurations backed up by environment variables.

**Breaking change:** Also remove parameters handling environment variables and dynamic variables from `from_file()`. It's better to handle these with explicit calls to `.add_envs()` and `.parse_dynamic()`.
